### PR TITLE
chore: release v0.1.0-alpha.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.0](https://github.com/hertelukas/syncthing-rs/releases/tag/v0.1.0-alpha.0) - 2025-05-08
+
+### Other
+
+- Setup release-plz
+- Fixed typo
+- Package setup
+- Create ci.yml
+- Create LICENSE-APACHE
+- Create LICENSE-MIT
+- used cargo clippy to fix issues
+- Using broadcast instead of mpsc
+- Debug for client
+- cargo fmt
+- Cluster endpoints
+- cluster/pending types
+- Functions to deal with single folders/devices
+- Endpoints for health and getting device id
+- Added logging
+- Testing events
+- Test for ping endpoint
+- Function to load config
+- Make lines pub
+- Complete config types
+- DeviceConfiguration complete
+- Configuration complete up to FolderConfiguration
+- Basic project structure
+- Initial commit


### PR DESCRIPTION



## 🤖 New release

* `syncthing-rs`: 0.1.0-alpha.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha.0](https://github.com/hertelukas/syncthing-rs/releases/tag/v0.1.0-alpha.0) - 2025-05-08

### Other

- Setup release-plz
- Fixed typo
- Package setup
- Create ci.yml
- Create LICENSE-APACHE
- Create LICENSE-MIT
- used cargo clippy to fix issues
- Using broadcast instead of mpsc
- Debug for client
- cargo fmt
- Cluster endpoints
- cluster/pending types
- Functions to deal with single folders/devices
- Endpoints for health and getting device id
- Added logging
- Testing events
- Test for ping endpoint
- Function to load config
- Make lines pub
- Complete config types
- DeviceConfiguration complete
- Configuration complete up to FolderConfiguration
- Basic project structure
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).