### PR TITLE
chore: release v0.1.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.1](https://github.com/hertelukas/syncthing-rs/compare/v0.1.0-alpha.0...v0.1.0-alpha.1) - 2025-05-09
+
+### Added
+
+- add initial #[derive(New)] macro crate scaffolding
+- default endpoints
+
+### Other
+
+- add badges to cargo.io
+- release v0.1.0-alpha.0
+
 ## [0.1.0-alpha.0](https://github.com/hertelukas/syncthing-rs/releases/tag/v0.1.0-alpha.0) - 2025-05-08
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-rs"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "chrono",
  "httpmock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncthing-rs"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Rust wrapper around the Syncthing API"


### PR DESCRIPTION



## 🤖 New release

* `syncthing-rs`: 0.1.0-alpha.0 -> 0.1.0-alpha.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha.1](https://github.com/hertelukas/syncthing-rs/compare/v0.1.0-alpha.0...v0.1.0-alpha.1) - 2025-05-09

### Added

- add initial #[derive(New)] macro crate scaffolding
- default endpoints

### Other

- add badges to cargo.io
- release v0.1.0-alpha.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).