### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-macros"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-rs"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "chrono",
  "httpmock",

--- a/syncthing-macros/CHANGELOG.md
+++ b/syncthing-macros/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.1](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.0...syncthing-macros-v0.1.0-alpha.1) - 2025-05-12
+
+### Added
+
+- *(macros)* allow into new from initial type
+- *(macros)* propagate rename_all attribute
+
+### Fixed
+
+- *(macros)* rename required fields too
+
+### Other
+
+- *(macros)* implement getter for all fields
+- *(macros)* apply cargo clippy recommendations
+- *(macros)* propagate #[serde(rename)] in #[derive(New)]
+- *(macros)* skip unset fields when serializing
+- *(macros)* use immutable builder style
+- *(macros)* cargo clippy feedback
+- ability to require fields in #[derive(New)]
+- *(macros)* setter functions for all fields
+- *(macros)* create default new()

--- a/syncthing-macros/Cargo.toml
+++ b/syncthing-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncthing-macros"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "syncthing-rs's macros."

--- a/syncthing-rs/CHANGELOG.md
+++ b/syncthing-rs/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha.2](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.1...syncthing-rs-v0.1.0-alpha.2) - 2025-05-12
+
+### Added
+
+- *(types)* derive New for devices and folders
+
+### Other
+
+- *(client)* avoid flaky test on get_events
+- *(client)* clippy
+- *(client)* test pending and defaults
+- *(client)* test add and post endpoints
+- *(client)* setup testcontainer to test agains syncthing
+- *(client)* accept for new everything thats into new

--- a/syncthing-rs/Cargo.toml
+++ b/syncthing-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncthing-rs"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Rust wrapper around the Syncthing API"
@@ -13,7 +13,7 @@ chrono = { version = "0.4.41", features = ["serde"] }
 log = "0.4.27"
 reqwest = { version = "0.12.15", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
-syncthing-macros = { version = "0.1.0-alpha.0", path = "../syncthing-macros" }
+syncthing-macros = { version = "0.1.0-alpha.1", path = "../syncthing-macros" }
 thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["full"] }
 


### PR DESCRIPTION



## 🤖 New release

* `syncthing-macros`: 0.1.0-alpha.0 -> 0.1.0-alpha.1
* `syncthing-rs`: 0.1.0-alpha.1 -> 0.1.0-alpha.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `syncthing-macros`

<blockquote>

## [0.1.0-alpha.1](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.0...syncthing-macros-v0.1.0-alpha.1) - 2025-05-12

### Added

- *(macros)* allow into new from initial type
- *(macros)* propagate rename_all attribute

### Fixed

- *(macros)* rename required fields too

### Other

- *(macros)* implement getter for all fields
- *(macros)* apply cargo clippy recommendations
- *(macros)* propagate #[serde(rename)] in #[derive(New)]
- *(macros)* skip unset fields when serializing
- *(macros)* use immutable builder style
- *(macros)* cargo clippy feedback
- ability to require fields in #[derive(New)]
- *(macros)* setter functions for all fields
- *(macros)* create default new()
</blockquote>

## `syncthing-rs`

<blockquote>

## [0.1.0-alpha.2](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.1...syncthing-rs-v0.1.0-alpha.2) - 2025-05-12

### Added

- *(types)* derive New for devices and folders

### Other

- *(client)* avoid flaky test on get_events
- *(client)* clippy
- *(client)* test pending and defaults
- *(client)* test add and post endpoints
- *(client)* setup testcontainer to test agains syncthing
- *(client)* accept for new everything thats into new
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).