### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2298,7 +2298,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-macros"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2310,7 +2310,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-rs"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "chrono",
  "httpmock",

--- a/syncthing-macros/CHANGELOG.md
+++ b/syncthing-macros/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.2](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.1...syncthing-macros-v0.1.0-alpha.2) - 2025-05-18
+
+### Added
+
+- #[derive(ParitalEq)] for all config types
+- *(macros)* #[derive(New)] types are clone
+
 ## [0.1.0-alpha.1](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.0...syncthing-macros-v0.1.0-alpha.1) - 2025-05-12
 
 ### Added

--- a/syncthing-macros/Cargo.toml
+++ b/syncthing-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncthing-macros"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "syncthing-rs's macros."

--- a/syncthing-rs/CHANGELOG.md
+++ b/syncthing-rs/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.2...syncthing-rs-v0.1.0-alpha.3) - 2025-05-18
+
+### Added
+
+- *(config)* delete folder/device endpoints
+- *(db)* get completion endpoint
+- *(system)* get connections endpoint
+- parsing all events
+- #[derive(ParitalEq)] for all config types
+- *(config)* everything is clone
+- *(events)* create NewDeviceConfiguration from event
+
+### Fixed
+
+- *(events)* fixed typo
+- *(events)* change type of folder scan progress
+- *(events)* change some types
+- *(client)* use & to indicate specific device's folder
+
+### Other
+
+- *(db)* completion fields pub
+- *(cluster)* made fields public
+- cargo clippy
+- use new API
+- *(client)* rename delete to dismiss
+
 ## [0.1.0-alpha.2](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.1...syncthing-rs-v0.1.0-alpha.2) - 2025-05-12
 
 ### Added

--- a/syncthing-rs/Cargo.toml
+++ b/syncthing-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncthing-rs"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Rust wrapper around the Syncthing API"
@@ -13,7 +13,7 @@ chrono = { version = "0.4.41", features = ["serde"] }
 log = "0.4.27"
 reqwest = { version = "0.12.15", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
-syncthing-macros = { version = "0.1.0-alpha.1", path = "../syncthing-macros" }
+syncthing-macros = { version = "0.1.0-alpha.2", path = "../syncthing-macros" }
 thiserror = "2.0.12"
 tokio = { version = "1.44.2", features = ["full"] }
 


### PR DESCRIPTION



## 🤖 New release

* `syncthing-macros`: 0.1.0-alpha.1 -> 0.1.0-alpha.2
* `syncthing-rs`: 0.1.0-alpha.2 -> 0.1.0-alpha.3 (⚠ API breaking changes)

### ⚠ `syncthing-rs` breaking changes

```text
--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Event no longer derives Eq, in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:14
  type EventType no longer derives Eq, in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:25

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field device of variant EventType::ClusterConfigReceived in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:27
  field version of variant EventType::ConfigSaved in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:31
  field folders of variant EventType::ConfigSaved in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:32
  field devices of variant EventType::ConfigSaved in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:33
  field gui of variant EventType::ConfigSaved in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:34
  field ldap of variant EventType::ConfigSaved in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:35
  field remote_ignored_devices of variant EventType::ConfigSaved in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:36
  field defaults of variant EventType::ConfigSaved in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:37
  field addrs of variant EventType::DeviceDiscovered in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:54
  field device of variant EventType::DeviceDiscovered in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:55
  field device of variant EventType::DeviceResumed in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:62
  field folders of variant EventType::DownloadProgress in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:66
  field completion of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:71
  field device of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:72
  field folder of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:73
  field global_bytes of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:74
  field global_items of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:75
  field need_bytes of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:76
  field need_deletes of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:77
  field need_items of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:78
  field remote_state of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:79
  field sequence of variant EventType::FolderCompletion in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:80
  field errors of variant EventType::FolderErrors in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:83
  field folder of variant EventType::FolderErrors in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:84
  field id of variant EventType::FolderPaused in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:87
  field label of variant EventType::FolderPaused in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:88
  field id of variant EventType::FolderResumed in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:92
  field label of variant EventType::FolderResumed in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:93
  field total of variant EventType::FolderScanProgress in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:96
  field rate of variant EventType::FolderScanProgress in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:97
  field current of variant EventType::FolderScanProgress in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:98
  field folder of variant EventType::FolderScanProgress in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:99
  field folder of variant EventType::FolderSummary in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:102
  field summary of variant EventType::FolderSummary in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:103
  field folder of variant EventType::FolderWatchStateChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:106
  field from of variant EventType::FolderWatchStateChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:107
  field to of variant EventType::FolderWatchStateChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:108
  field item of variant EventType::ItemFinished in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:111
  field folder of variant EventType::ItemFinished in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:112
  field error of variant EventType::ItemFinished in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:113
  field ty of variant EventType::ItemFinished in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:115
  field action of variant EventType::ItemFinished in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:116
  field item of variant EventType::ItemStarted in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:119
  field folder of variant EventType::ItemStarted in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:120
  field ty of variant EventType::ItemStarted in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:122
  field action of variant EventType::ItemStarted in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:123
  field address of variant EventType::ListenAddressesChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:126
  field wan of variant EventType::ListenAddressesChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:127
  field lan of variant EventType::ListenAddressesChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:128
  field action of variant EventType::LocalChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:131
  field folder of variant EventType::LocalChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:132
  field folder_id of variant EventType::LocalChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:134
  field label of variant EventType::LocalChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:135
  field path of variant EventType::LocalChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:136
  field ty of variant EventType::LocalChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:138
  field folder of variant EventType::LocalIndexUpdated in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:141
  field items of variant EventType::LocalIndexUpdated in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:142
  field filenames of variant EventType::LocalIndexUpdated in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:143
  field sequence of variant EventType::LocalIndexUpdated in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:144
  field remote_address of variant EventType::LoginAttempt in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:148
  field username of variant EventType::LoginAttempt in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:149
  field success of variant EventType::LoginAttempt in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:150
  field proxy of variant EventType::LoginAttempt in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:151
  field ty of variant EventType::RemoteChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:164
  field action of variant EventType::RemoteChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:165
  field folder of variant EventType::RemoteChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:166
  field folder_id of variant EventType::RemoteChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:168
  field path of variant EventType::RemoteChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:169
  field label of variant EventType::RemoteChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:170
  field modified_by of variant EventType::RemoteChangeDetected in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:171
  field state of variant EventType::RemoteDownloadProgress in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:174
  field device of variant EventType::RemoteDownloadProgress in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:175
  field folder of variant EventType::RemoteDownloadProgress in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:176
  field device of variant EventType::RemoteIndexUpdated in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:179
  field folder of variant EventType::RemoteIndexUpdated in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:180
  field items of variant EventType::RemoteIndexUpdated in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:181
  field home of variant EventType::Starting in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:184
  field my_id of variant EventType::StartupComplete in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:188
  field folder of variant EventType::StateChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:191
  field from of variant EventType::StateChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:192
  field duration of variant EventType::StateChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:193
  field to of variant EventType::StateChanged in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:194

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant EventType:DevicePaused in /tmp/.tmpP74wf9/syncthing-rs/syncthing-rs/src/types/events.rs:57

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_missing.ron

Failed in:
  variant EventType::DevicePause, previously in file /tmp/.tmpOx4k8P/syncthing-rs/src/types/events.rs:36

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  Client::delete_pending_device, previously in file /tmp/.tmpOx4k8P/syncthing-rs/src/client.rs:329
  Client::delete_pending_folder, previously in file /tmp/.tmpOx4k8P/syncthing-rs/src/client.rs:348
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `syncthing-macros`

<blockquote>

## [0.1.0-alpha.2](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.1...syncthing-macros-v0.1.0-alpha.2) - 2025-05-18

### Added

- #[derive(ParitalEq)] for all config types
- *(macros)* #[derive(New)] types are clone
</blockquote>

## `syncthing-rs`

<blockquote>

## [0.1.0-alpha.3](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.2...syncthing-rs-v0.1.0-alpha.3) - 2025-05-18

### Added

- *(config)* delete folder/device endpoints
- *(db)* get completion endpoint
- *(system)* get connections endpoint
- parsing all events
- #[derive(ParitalEq)] for all config types
- *(config)* everything is clone
- *(events)* create NewDeviceConfiguration from event

### Fixed

- *(events)* fixed typo
- *(events)* change type of folder scan progress
- *(events)* change some types
- *(client)* use & to indicate specific device's folder

### Other

- *(db)* completion fields pub
- *(cluster)* made fields public
- cargo clippy
- use new API
- *(client)* rename delete to dismiss
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).