### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,7 +2358,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-macros"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2370,7 +2370,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-rs"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "chrono",
  "httpmock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-macros"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "syncthing-rs"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "chrono",
  "httpmock",

--- a/syncthing-macros/CHANGELOG.md
+++ b/syncthing-macros/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.2...syncthing-macros-v0.1.0-alpha.3) - 2026-04-25
+
+### Fixed
+
+- collapse nested if blocks (clippy)
+
+### Other
+
+- *(deps)* update dependencies
+- *(macros)* cargo fmt
+- cargo clippy
+
 ## [0.1.0-alpha.2](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.1...syncthing-macros-v0.1.0-alpha.2) - 2025-05-18
 
 ### Added

--- a/syncthing-macros/CHANGELOG.md
+++ b/syncthing-macros/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.3](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.2...syncthing-macros-v0.1.0-alpha.3) - 2026-06-25
+
+### Fixed
+
+- collapse nested if blocks (clippy)
+
+### Other
+
+- *(deps)* upgrade dependencies
+- *(deps)* update dependencies
+- *(macros)* cargo fmt
+- cargo clippy
+
 ## [0.1.0-alpha.2](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.1...syncthing-macros-v0.1.0-alpha.2) - 2025-05-18
 
 ### Added

--- a/syncthing-macros/Cargo.toml
+++ b/syncthing-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncthing-macros"
-version = "0.1.0-alpha.2"
+version = "0.1.0-alpha.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "syncthing-rs's macros."

--- a/syncthing-rs/CHANGELOG.md
+++ b/syncthing-rs/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.4](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.3...syncthing-rs-v0.1.0-alpha.4) - 2026-04-25
+
+### Added
+
+- *(events)* parse state changes as enum
+
+### Fixed
+
+- *(events)* typo in file download progress
+
+### Other
+
+- *(deps)* upgrade dependencies
+- *(deps)* update dependencies
+- *(tests)* cargo fmt
+- *(tests)* cargo clippy
+- update compatibility for syncthing 2.0
+- cargo clippy
+- *(events)* add missing download progress field
+
 ## [0.1.0-alpha.3](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.2...syncthing-rs-v0.1.0-alpha.3) - 2025-05-18
 
 ### Added

--- a/syncthing-rs/CHANGELOG.md
+++ b/syncthing-rs/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.4](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.3...syncthing-rs-v0.1.0-alpha.4) - 2026-06-25
+
+### Added
+
+- *(events)* parse state changes as enum
+
+### Fixed
+
+- *(events)* typo in file download progress
+
+### Other
+
+- *(deps)* upgrade dependencies
+- *(deps)* upgrade dependencies
+- *(deps)* update dependencies
+- *(tests)* cargo fmt
+- *(tests)* cargo clippy
+- update compatibility for syncthing 2.0
+- cargo clippy
+- *(events)* add missing download progress field
+
 ## [0.1.0-alpha.3](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.2...syncthing-rs-v0.1.0-alpha.3) - 2025-05-18
 
 ### Added

--- a/syncthing-rs/Cargo.toml
+++ b/syncthing-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncthing-rs"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Rust wrapper around the Syncthing API"
@@ -13,7 +13,7 @@ chrono = { version = "0.4.44", features = ["serde"] }
 log = "0.4.29"
 reqwest = { version = "0.13.2", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
-syncthing-macros = { version = "0.1.0-alpha.2", path = "../syncthing-macros" }
+syncthing-macros = { version = "0.1.0-alpha.3", path = "../syncthing-macros" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["full"] }
 

--- a/syncthing-rs/Cargo.toml
+++ b/syncthing-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "syncthing-rs"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Rust wrapper around the Syncthing API"
@@ -13,7 +13,7 @@ chrono = { version = "0.4.45", features = ["serde"] }
 log = "0.4.33"
 reqwest = { version = "0.13.4", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
-syncthing-macros = { version = "0.1.0-alpha.2", path = "../syncthing-macros" }
+syncthing-macros = { version = "0.1.0-alpha.3", path = "../syncthing-macros" }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 


### PR DESCRIPTION



## 🤖 New release

* `syncthing-macros`: 0.1.0-alpha.2 -> 0.1.0-alpha.3
* `syncthing-rs`: 0.1.0-alpha.3 -> 0.1.0-alpha.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `syncthing-macros`

<blockquote>

## [0.1.0-alpha.3](https://github.com/hertelukas/syncthing-rs/compare/syncthing-macros-v0.1.0-alpha.2...syncthing-macros-v0.1.0-alpha.3) - 2026-06-25

### Fixed

- collapse nested if blocks (clippy)

### Other

- *(deps)* upgrade dependencies
- *(deps)* update dependencies
- *(macros)* cargo fmt
- cargo clippy
</blockquote>

## `syncthing-rs`

<blockquote>

## [0.1.0-alpha.4](https://github.com/hertelukas/syncthing-rs/compare/syncthing-rs-v0.1.0-alpha.3...syncthing-rs-v0.1.0-alpha.4) - 2026-06-25

### Added

- *(events)* parse state changes as enum

### Fixed

- *(events)* typo in file download progress

### Other

- *(deps)* upgrade dependencies
- *(deps)* upgrade dependencies
- *(deps)* update dependencies
- *(tests)* cargo fmt
- *(tests)* cargo clippy
- update compatibility for syncthing 2.0
- cargo clippy
- *(events)* add missing download progress field
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).